### PR TITLE
Fix autocannon aim range override

### DIFF
--- a/Ruleset/items_FMPE.rul
+++ b/Ruleset/items_FMPE.rul
@@ -2435,7 +2435,7 @@ items:
     accuracyCloseQuarters: 55
     sprayWaypoints: 2
     shotgunChoke: 80
-    aimRange: 22
+    aimRange: 25
   - type: STR_AC_AP_AMMO
     categories: [STR_HUMAN_TECH, STR_FIREARMS, STR_CANNONS, STR_HEAVY_WEAPONS, STR_CLIPS, STR_LAND]
     damageAlter:


### PR DESCRIPTION
In FMP Auto cannon Snap and auto range set to 25. Additionally FMPE override aim range to 22. 
It is strange that AIM range is lower than snapshot range.
Reference to FMP autocannon values:
https://github.com/SolariusScorch/Final-Mod-Pack/blob/cb844fa8752a5f0a2f4af041229f674b258b8398/Ruleset/items_FMP.rul#L4045

Solution:
Change aim range for Auto Cannon to 25. Now it matches with snap and auto range.
